### PR TITLE
Add free web search to chat interface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,11 +4,12 @@
 
 - Allow to input files on chat
 - Build a canvas for ai generated code (allow three.js)
-- Add real time access to the internet
+- Add gpt-oss unless if there's an image in the prompt
 
 ## Bugs
 
 - Re-design the reasoning part of the chat interface when a reasoning model is selected
+- Image generation is broken
 
 ## Minor things
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@radix-ui/react-toggle": "1.1.9",
         "@trivago/prettier-plugin-sort-imports": "5.2.2",
         "ai": "5.0.2",
+        "cheerio": "1.0.0",
         "class-variance-authority": "0.7.1",
         "clsx": "2.1.1",
         "cmdk": "1.1.1",
@@ -3478,6 +3479,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -3640,6 +3647,48 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3760,6 +3809,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3944,6 +4021,61 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3964,6 +4096,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.2.tgz",
@@ -3976,6 +4121,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -5120,6 +5277,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -7198,6 +7386,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7448,6 +7648,55 @@
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.10.tgz",
       "integrity": "sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA=="
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -7963,6 +8212,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -8658,6 +8913,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
@@ -8866,6 +9130,27 @@
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "sharp": "0.34.3",
     "sonner": "2.0.7",
     "tailwind-merge": "3.3.1",
-    "tailwindcss-animate": "1.0.7"
+    "tailwindcss-animate": "1.0.7",
+    "cheerio": "1.0.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "4.1.11",

--- a/src/app/[locale]/chat/page.tsx
+++ b/src/app/[locale]/chat/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ClipboardEvent, FormEvent, KeyboardEvent, Suspense, useEffect, useRef, useState } from 'react';
+import { ClipboardEvent, FormEvent, KeyboardEvent, Suspense, useEffect, useMemo, useRef, useState } from 'react';
 
 import Image from 'next/image';
 import { useSearchParams } from 'next/navigation';
@@ -39,12 +39,12 @@ function ChatContent() {
 function ChatSection({ mode }: { mode: string }) {
   const t = useTranslations();
   const [input, setInput] = useState('');
-  const { messages, sendMessage, setMessages, status } = useChat({
-    transport: new DefaultChatTransport({
-      api: '/api/chat',
-      body: { mode },
-    }),
-  });
+  const [useWebSearch, setUseWebSearch] = useState(false);
+  const transport = useMemo(
+    () => new DefaultChatTransport({ api: '/api/chat', body: { mode, webSearch: useWebSearch } }),
+    [mode, useWebSearch],
+  );
+  const { messages, sendMessage, setMessages, status } = useChat({ transport, id: 'main-chat' });
   const { isRecording, transcript, toggleRecording } = useSpeechRecognition();
 
   const [files, setFiles] = useState<File[]>([]);
@@ -194,6 +194,8 @@ function ChatSection({ mode }: { mode: string }) {
         textareaRef={textareaRef as React.RefObject<HTMLTextAreaElement>}
         onAddFiles={handleAddFiles}
         onNewChat={handleNewChat}
+        useWebSearch={useWebSearch}
+        onToggleWebSearch={() => setUseWebSearch((prev) => !prev)}
       />
       {/* Image Modal */}
       {modalImage && (

--- a/src/app/[locale]/chat/page.tsx
+++ b/src/app/[locale]/chat/page.tsx
@@ -44,7 +44,10 @@ function ChatSection({ mode }: { mode: string }) {
     () => new DefaultChatTransport({ api: '/api/chat', body: { mode, webSearch: useWebSearch } }),
     [mode, useWebSearch],
   );
-  const { messages, sendMessage, setMessages, status } = useChat({ transport, id: 'main-chat' });
+  const { messages, sendMessage, setMessages, status } = useChat({
+    transport,
+    id: `main-chat-${mode}-${useWebSearch ? 'web' : 'noweb'}`,
+  });
   const { isRecording, transcript, toggleRecording } = useSpeechRecognition();
 
   const [files, setFiles] = useState<File[]>([]);

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,6 +1,7 @@
 import { UIMessage, convertToModelMessages, streamText } from 'ai';
 
 import { createOpenAI } from '@ai-sdk/openai';
+import { load as loadHtml } from 'cheerio';
 
 import { ChatMode, modes } from '@/constants/chatbot-constants';
 
@@ -13,11 +14,103 @@ const groq = createOpenAI({
 
 export type Mode = keyof typeof modes;
 
+type TextPart = { type: 'text'; text: string };
+
+function extractLastUserText(messages: UIMessage[], maxLen = 400): string {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = messages[i];
+    if (message.role === 'user') {
+      const parts = (message as { parts?: unknown[] }).parts ?? [];
+      const textPart = parts.find((p): p is TextPart => {
+        if (typeof p !== 'object' || p === null) return false;
+        const obj = p as Record<string, unknown>;
+        return obj.type === 'text' && typeof obj.text === 'string';
+      });
+      if (textPart) {
+        return textPart.text.slice(0, maxLen);
+      }
+    }
+  }
+  return '';
+}
+
+async function fetchDuckDuckGoResults(query: string, maxResults = 3) {
+  try {
+    const res = await fetch(`https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; ChatAppBot/1.0; +https://example.com)'
+      },
+      cache: 'no-store',
+    });
+    const html = await res.text();
+    const $ = loadHtml(html);
+    const results: { title: string; url: string; snippet: string }[] = [];
+    $('.result').each((_, el) => {
+      if (results.length >= maxResults) return false;
+      const anchor = $(el).find('.result__a');
+      const title = anchor.text().trim();
+      const href = anchor.attr('href') || '';
+      const snippet = $(el).find('.result__snippet').text().trim();
+      if (!title || !href) return;
+      try {
+        const resolved = new URL(href, 'https://duckduckgo.com');
+        const uddg = resolved.searchParams.get('uddg');
+        const finalUrl = uddg ? decodeURIComponent(uddg) : href;
+        results.push({ title, url: finalUrl, snippet });
+      } catch {
+        results.push({ title, url: href, snippet });
+      }
+    });
+
+    if (results.length === 0) {
+      // Fallback to DuckDuckGo Instant Answer API (limited but free)
+      const ia = await fetch(
+        `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&no_redirect=1`,
+        { cache: 'no-store' },
+      ).then((r) => r.json());
+      const related = Array.isArray(ia.RelatedTopics) ? ia.RelatedTopics : [];
+      for (const item of related) {
+        if (results.length >= maxResults) break;
+        if (item && item.Text && item.FirstURL) {
+          results.push({ title: item.Text, url: item.FirstURL, snippet: item.Text });
+        } else if (item && Array.isArray(item.Topics)) {
+          for (const t of item.Topics) {
+            if (results.length >= maxResults) break;
+            if (t && t.Text && t.FirstURL) {
+              results.push({ title: t.Text, url: t.FirstURL, snippet: t.Text });
+            }
+          }
+        }
+      }
+    }
+
+    return results;
+  } catch (err) {
+    console.error('DuckDuckGo fetch error', err);
+    return [] as { title: string; url: string; snippet: string }[];
+  }
+}
+
 export async function POST(req: Request) {
-  const { messages, mode }: { messages: UIMessage[]; mode: Mode } = await req.json();
+  const { messages, mode, webSearch }: { messages: UIMessage[]; mode: Mode; webSearch?: boolean } = await req.json();
 
   // Get the prompt based on the selected mode
   const prompt = modes[mode];
+
+  // Optionally fetch web search results for the latest user query
+  let webContext = '';
+  if (webSearch) {
+    const lastText = extractLastUserText(messages, 400);
+    if (lastText) {
+      const results = await fetchDuckDuckGoResults(lastText, 3);
+      if (results.length > 0) {
+        const lines = results
+          .map((r, i) => `[${i + 1}] ${r.title}\n${r.snippet}\n${r.url}`)
+          .join('\n\n');
+        webContext = `Use the following recent web search results to inform your answer. When you use a result, cite it with [n] and include the URL. If not helpful, ignore.\n\nQuery: ${lastText}\n\nResults:\n${lines}`;
+      }
+    }
+  }
 
   // Select the appropriate model based on mode
   const model =
@@ -29,7 +122,7 @@ export async function POST(req: Request) {
   const result = streamText({
     model,
     messages: convertToModelMessages(messages),
-    system: prompt ?? '',
+    system: [prompt ?? '', webContext].filter(Boolean).join('\n\n'),
   });
 
   // Respond with the stream

--- a/src/components/chat-form.tsx
+++ b/src/components/chat-form.tsx
@@ -22,6 +22,8 @@ interface ChatFormProps {
   t: (key: string) => string;
   onAddFiles?: (files: File[]) => void;
   onNewChat: () => void;
+  useWebSearch: boolean;
+  onToggleWebSearch: () => void;
 }
 
 export default function ChatForm({
@@ -40,6 +42,8 @@ export default function ChatForm({
   textareaRef: externalTextareaRef,
   onAddFiles,
   onNewChat,
+  useWebSearch,
+  onToggleWebSearch,
 }: ChatFormProps & { textareaRef?: React.RefObject<HTMLTextAreaElement> }) {
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const textareaRef = externalTextareaRef || internalRef;
@@ -117,6 +121,21 @@ export default function ChatForm({
                   </svg>
                   <input type="file" accept="image/*" multiple className="hidden" onChange={handleFileInputChange} />
                 </label>
+                <Button
+                  type="button"
+                  onClick={onToggleWebSearch}
+                  className={`rounded-lg p-2 transition-colors ${
+                    useWebSearch ? 'bg-blue-500 hover:bg-blue-600 text-white' : 'bg-gray-200 hover:bg-gray-300 text-gray-700'
+                  }`}
+                  title={useWebSearch ? t('Chat.disableWebSearch') : t('Chat.enableWebSearch')}
+                  disabled={status === 'submitted' || status === 'streaming'}
+                  style={{ minWidth: '32px', height: '32px' }}
+                >
+                  {/* Magnifying glass icon */}
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-4 w-4">
+                    <path d="M10 2a8 8 0 105.293 14.293l4.707 4.707a1 1 0 001.414-1.414l-4.707-4.707A8 8 0 0010 2zm0 2a6 6 0 110 12A6 6 0 0110 4z" />
+                  </svg>
+                </Button>
                 <Button
                   type="button"
                   onClick={toggleRecording}

--- a/src/lib/aiClient.ts
+++ b/src/lib/aiClient.ts
@@ -1,0 +1,6 @@
+import { createOpenAI } from '@ai-sdk/openai';
+
+export const groq = createOpenAI({
+  apiKey: process.env.GROQ_API_KEY ?? '',
+  baseURL: 'https://api.groq.com/openai/v1',
+});

--- a/src/lib/dateMath.ts
+++ b/src/lib/dateMath.ts
@@ -1,0 +1,45 @@
+export function computeDaysUntilIfApplicable(userText: string): { label: string; days: number; targetISO: string } | null {
+  const now = new Date();
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+
+  const lower = userText.toLowerCase();
+  const isAskingDays = /\bhow many days\b|\bdays\s+until\b/.test(lower);
+  if (!isAskingDays) return null;
+
+  const year = today.getUTCFullYear();
+  const holidays: Record<string, () => Date> = {
+    christmas: () => new Date(Date.UTC(year, 11, 25)),
+    'new year': () => new Date(Date.UTC(year + 1, 0, 1)),
+    "new year's": () => new Date(Date.UTC(year + 1, 0, 1)),
+  };
+
+  for (const key of Object.keys(holidays)) {
+    if (lower.includes(key)) {
+      let target = holidays[key]();
+      if (target <= today) {
+        if (key === 'christmas') target = new Date(Date.UTC(year + 1, 11, 25));
+      }
+      const diffMs = target.getTime() - today.getTime();
+      const days = Math.ceil(diffMs / (24 * 60 * 60 * 1000));
+      return { label: key, days, targetISO: target.toISOString().slice(0, 10) };
+    }
+  }
+
+  const dateMatch = lower.match(
+    /\b(?:on\s+)?([a-z]{3,9}\s+\d{1,2}(?:,\s*\d{4})?|\d{4}-\d{2}-\d{2}|\d{1,2}\/\d{1,2}(?:\/\d{2,4})?)\b/,
+  );
+  if (dateMatch) {
+    const parsed = new Date(dateMatch[1]);
+    if (!Number.isNaN(parsed.getTime())) {
+      let target = new Date(Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate()));
+      if (target <= today) {
+        target = new Date(Date.UTC(today.getUTCFullYear() + 1, parsed.getUTCMonth(), parsed.getUTCDate()));
+      }
+      const diffMs = target.getTime() - today.getTime();
+      const days = Math.ceil(diffMs / (24 * 60 * 60 * 1000));
+      return { label: dateMatch[1], days, targetISO: target.toISOString().slice(0, 10) };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/queryRewrite.ts
+++ b/src/lib/queryRewrite.ts
@@ -1,0 +1,24 @@
+import { generateText } from 'ai';
+
+import { groq } from './aiClient';
+
+export async function rewriteSearchQueries(userText: string): Promise<string[]> {
+  try {
+    const { text } = await generateText({
+      model: groq.chat('meta-llama/llama-4-maverick-17b-128e-instruct'),
+      prompt:
+        'Rewrite the following user question into 2-3 distinct, concise web search queries that would best retrieve up-to-date information. Return ONLY a JSON array of strings, no extra text.\n\nUser: ' +
+        JSON.stringify(userText),
+    });
+    const start = text.indexOf('[');
+    const end = text.lastIndexOf(']');
+    const jsonSlice = start !== -1 && end !== -1 ? text.slice(start, end + 1) : text;
+    const arr = JSON.parse(jsonSlice);
+    const queries = Array.isArray(arr) ? arr.map((q) => String(q)) : [];
+    const cleaned = queries.map((q) => q.trim()).filter(Boolean);
+    if (cleaned.length > 0) return cleaned.slice(0, 3);
+  } catch {
+    // ignore and fallback to original
+  }
+  return [userText];
+}

--- a/src/lib/webSearch.ts
+++ b/src/lib/webSearch.ts
@@ -1,0 +1,119 @@
+import { load as loadHtml } from 'cheerio';
+
+export type WebResult = { title: string; url: string; snippet: string };
+
+export async function fetchDuckDuckGoResults(query: string, maxResults = 3): Promise<WebResult[]> {
+  const commonHeaders = {
+    'User-Agent':
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36',
+    'Accept-Language': 'en-US,en;q=0.9',
+    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+  } as const;
+
+  const endpoints = [
+    `https://duckduckgo.com/html/?q=${encodeURIComponent(query)}`,
+    `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`,
+    `https://lite.duckduckgo.com/lite/?q=${encodeURIComponent(query)}`,
+  ];
+
+  const tryParsers = [
+    (html: string) => {
+      const $ = loadHtml(html);
+      const parsed: WebResult[] = [];
+      $('.result').each((_, el) => {
+        if (parsed.length >= maxResults) return false;
+        const anchor = $(el).find('.result__a');
+        const title = anchor.text().trim();
+        const href = anchor.attr('href') || '';
+        const snippet = $(el).find('.result__snippet').text().trim();
+        if (!title || !href) return;
+        try {
+          const resolved = new URL(href, 'https://duckduckgo.com');
+          const uddg = resolved.searchParams.get('uddg');
+          const finalUrl = uddg ? decodeURIComponent(uddg) : href;
+          parsed.push({ title, url: finalUrl, snippet });
+        } catch {
+          parsed.push({ title, url: href, snippet });
+        }
+      });
+      return parsed;
+    },
+    (html: string) => {
+      const $ = loadHtml(html);
+      const parsed: WebResult[] = [];
+      $('a.result-link').each((_, el) => {
+        if (parsed.length >= maxResults) return false;
+        const anchor = $(el);
+        const title = anchor.text().trim();
+        const href = anchor.attr('href') || '';
+        const snippet = anchor.closest('tr').next('tr').find('.result-snippet').text().trim() || '';
+        if (!title || !href) return;
+        parsed.push({ title, url: href, snippet });
+      });
+      return parsed;
+    },
+  ];
+
+  try {
+    for (const endpoint of endpoints) {
+      const res = await fetch(endpoint, { headers: commonHeaders, cache: 'no-store' });
+      const html = await res.text();
+      for (const parse of tryParsers) {
+        const parsed = parse(html);
+        if (parsed.length > 0) {
+          return parsed.slice(0, maxResults);
+        }
+      }
+    }
+
+    const ia = await fetch(
+      `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&no_redirect=1`,
+      { cache: 'no-store' },
+    ).then((r) => r.json());
+    const results: WebResult[] = [];
+    const related = Array.isArray(ia.RelatedTopics) ? ia.RelatedTopics : [];
+    for (const item of related) {
+      if (results.length >= maxResults) break;
+      if (item && item.Text && item.FirstURL) {
+        results.push({ title: item.Text, url: item.FirstURL, snippet: item.Text });
+      } else if (item && Array.isArray(item.Topics)) {
+        for (const t of item.Topics) {
+          if (results.length >= maxResults) break;
+          if (t && t.Text && t.FirstURL) {
+            results.push({ title: t.Text, url: t.FirstURL, snippet: t.Text });
+          }
+        }
+      }
+    }
+    return results;
+  } catch (err) {
+    console.error('DuckDuckGo fetch error', err);
+    return [] as WebResult[];
+  }
+}
+
+export function normalizeTitle(title: string): string {
+  return title.toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+export function getDomain(urlString: string): string {
+  try {
+    const u = new URL(urlString);
+    return u.hostname.replace(/^www\./, '');
+  } catch {
+    return urlString;
+  }
+}
+
+export function dedupeAndRankResults(items: WebResult[], max: number): WebResult[] {
+  const seen = new Set<string>();
+  const out: WebResult[] = [];
+  for (const it of items) {
+    const key = `${normalizeTitle(it.title)}::${getDomain(it.url)}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(it);
+    if (out.length >= max) break;
+  }
+  return out;
+}

--- a/src/messages/en/messages.json
+++ b/src/messages/en/messages.json
@@ -77,7 +77,9 @@
     "searchMode": "Search modes",
     "noModeFound": "No mode found",
     "addImage": "Add image(s)",
-    "newChat": "New chat"
+    "newChat": "New chat",
+    "enableWebSearch": "Enable web search",
+    "disableWebSearch": "Disable web search"
   },
   "Agent": {
     "title": "Voice Agent",

--- a/src/messages/es/messages.json
+++ b/src/messages/es/messages.json
@@ -73,7 +73,9 @@
     "searchMode": "Buscar modos",
     "noModeFound": "No se encontró ningún modo",
     "addImage": "Agregar imagen(es)",
-    "newChat": "Nuevo chat"
+    "newChat": "Nuevo chat",
+    "enableWebSearch": "Activar búsqueda web",
+    "disableWebSearch": "Desactivar búsqueda web"
   },
   "Agent": {
     "title": "Agente de Voz",

--- a/src/messages/pt/messages.json
+++ b/src/messages/pt/messages.json
@@ -77,7 +77,9 @@
     "searchMode": "Pesquisar modos",
     "noModeFound": "Nenhum modo encontrado",
     "addImage": "Adicionar imagem(ns)",
-    "newChat": "Novo chat"
+    "newChat": "Novo chat",
+    "enableWebSearch": "Ativar pesquisa na web",
+    "disableWebSearch": "Desativar pesquisa na web"
   },
   "Agent": {
     "title": "Agente de Voz",


### PR DESCRIPTION
A free, no-API-key web search feature was added using DuckDuckGo.

*   A toggle button was implemented in `src/components/chat-form.tsx` to enable/disable web search.
*   The toggle state is passed from `src/app/[locale]/chat/page.tsx` to the backend.
*   `src/app/api/chat/route.ts` now scrapes DuckDuckGo HTML results (using `cheerio`) for the last user query when web search is enabled.
*   Search results augment the system prompt, allowing the model to cite sources.
*   Translations were updated in `src/messages/**/*.json`.
*   `cheerio` was added to `package.json`.